### PR TITLE
Add NETCONF server for port control

### DIFF
--- a/.github/workflows/splitter.yml
+++ b/.github/workflows/splitter.yml
@@ -13,8 +13,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install Conan
+        run: pip install conan
+      - name: Install dependencies
+        run: |
+          conan profile detect --force
+          conan install . --output-folder build --build=missing
       - name: Configure
-        run: cmake -S . -B build
+        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
       - name: Build
         run: cmake --build build
       - name: Build MCU

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,12 @@ target_compile_options(splitter PRIVATE -O2 -Wall)
 
 # Build daemon that receives protobuf messages
 find_package(Protobuf REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+find_package(Threads REQUIRED)
 add_executable(monitor_daemon src/daemon/monitor_daemon.cpp src/proto/splitter.pb.cc)
 target_include_directories(monitor_daemon PRIVATE src src/proto ${Protobuf_INCLUDE_DIRS})
-target_link_libraries(monitor_daemon PRIVATE protobuf::libprotobuf)
-target_compile_options(monitor_daemon PRIVATE -O2 -Wall)
+target_link_libraries(monitor_daemon PRIVATE protobuf::libprotobuf Boost::system Threads::Threads)
+target_compile_options(monitor_daemon PRIVATE -O0 -Wall)
 
 enable_testing()
 
@@ -39,6 +41,11 @@ add_executable(uart_writer_test tests/uart_writer_test.cpp src/stm32/uart_writer
 target_include_directories(uart_writer_test PRIVATE src src/stm32)
 target_compile_options(uart_writer_test PRIVATE -fno-exceptions)
 add_test(NAME uart_writer_test COMMAND uart_writer_test)
+
+add_executable(netconf_server_test tests/netconf_server_test.cpp)
+target_include_directories(netconf_server_test PRIVATE src)
+target_link_libraries(netconf_server_test PRIVATE Boost::system Threads::Threads)
+add_test(NAME netconf_server_test COMMAND netconf_server_test)
 
 add_test(NAME monitor_daemon_report
   COMMAND bash -c "printf 'report { center_mhz: 1.23 } crc32: 3670215876' | protoc -I ${CMAKE_SOURCE_DIR}/proto --encode=splitter.Envelope ${CMAKE_SOURCE_DIR}/proto/splitter.proto | $<TARGET_FILE:monitor_daemon> > /dev/null")

--- a/README.md
+++ b/README.md
@@ -6,29 +6,29 @@ The C++ demo computes the center frequency of a synthetic signal using an FFT an
 
 ## Prerequisites
 
-The daemon and tests depend on Protobuf and Boost. On Ubuntu these can be
-installed with:
+The project uses Conan to provide the required third-party packages such as
+Protobuf and Boost.  Install Conan (``pip install conan`` if needed) and let it
+detect your host profile:
 
 ```
-sudo apt-get install protobuf-compiler libprotobuf-dev libboost-all-dev
+conan profile detect --force
 ```
 
 ## Build and run
 
-Build and run using CMake:
+Install dependencies and build using CMake:
 
 ```
-mkdir build
-cd build
-cmake ..
-cmake --build .
-./splitter
+conan install . --output-folder build --build=missing
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
+cmake --build build
+./build/splitter
 ```
 
 Run unit tests with CTest:
 
 ```
-ctest
+cd build && ctest
 ```
 
 The Angular component (`web/port-status.component.*`) illustrates how a frontend might interact with the backend.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This directory contains sample C++ code and an Angular component stub for a 32-p
 
 The C++ demo computes the center frequency of a synthetic signal using an FFT and stores the result in a `PortState` object.
 
+## Prerequisites
+
+The daemon and tests depend on Protobuf and Boost. On Ubuntu these can be
+installed with:
+
+```
+sudo apt-get install protobuf-compiler libprotobuf-dev libboost-all-dev
+```
+
+## Build and run
+
 Build and run using CMake:
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ ctest
 
 The Angular component (`web/port-status.component.*`) illustrates how a frontend might interact with the backend.
 
+An example Nginx configuration in `web/nginx.conf` shows how to serve the
+compiled Angular assets while terminating TLS and proxying `/ws` WebSocket
+requests to the daemon running on port 9002.
+
 ## STM32 microcontroller implementation
 
 An embedded variant places the FFT and monitoring on an STM32 MCU using the CMSIS-DSP library. Example code in `src/stm32/fft_monitor.cpp` computes the center frequency of a sample buffer and sends the result over UART.
@@ -30,4 +34,4 @@ The embedded build forbids C++ exceptions. A standalone CMake project in `src/st
 
 ## Protobuf protocol and daemon
 
-A lightweight protocol defined in `proto/splitter.proto` allows the microcontroller to send FFT reports or receive commands such as start/stop and enabling or disabling individual ports. Each envelope includes a CRC32 checksum for basic integrity checking. A simple daemon (`monitor_daemon`) parses these protobuf messages on the Linux SBC, verifies the checksum, and prints the results.
+A lightweight protocol defined in `proto/splitter.proto` allows the microcontroller to send FFT reports or receive commands such as start/stop and enabling or disabling individual ports. Each envelope includes a CRC32 checksum for basic integrity checking. A simple daemon (`monitor_daemon`) parses these protobuf messages on the Linux SBC, verifies the checksum, and prints the results. The daemon also launches a WebSocket server for communication with the Angular frontend and exposes a NETCONF interface for external control and monitoring, enabling remote clients to toggle ports and query their detected center frequencies.

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,10 @@
+[requires]
+boost/1.83.0
+protobuf/3.21.12
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[layout]
+cmake_layout

--- a/src/daemon/monitor_daemon.cpp
+++ b/src/daemon/monitor_daemon.cpp
@@ -2,9 +2,23 @@
 #include <string>
 #include "splitter.pb.h"
 #include "crc32.hpp"
+#include "websocket_server.hpp"
+#include "netconf_server.hpp"
+#include "PortState.hpp"
+#include <vector>
 
 int main() {
     GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+    std::vector<PortState> ports(32);
+
+    // Start WebSocket interface for Angular frontend
+    WebSocketServer ws(9002);
+    ws.run();
+
+    // NETCONF server for control and monitoring
+    NetconfServer netconf(ports);
+    netconf.start();
 
     splitter::Envelope env;
     if (!env.ParseFromIstream(&std::cin)) {

--- a/src/daemon/netconf_server.hpp
+++ b/src/daemon/netconf_server.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "PortState.hpp"
+#include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <thread>
+#include <vector>
+
+// Minimal NETCONF server. Supports enabling/disabling ports via <edit-config>
+// and retrieving port state via <get>.
+class NetconfServer {
+public:
+    NetconfServer(std::vector<PortState>& ports, unsigned short port = 8300)
+        : ports_(ports),
+          acceptor_(ioc_, {boost::asio::ip::tcp::v4(), port}),
+          eom_("\x5D\x5D\x3E\x5D\x5D\x3E") {}
+
+    void start() {
+        std::thread([this] {
+            for (;;) {
+                boost::asio::ip::tcp::socket socket(ioc_);
+                acceptor_.accept(socket);
+                std::thread(&NetconfServer::session, this, std::move(socket))
+                    .detach();
+            }
+        }).detach();
+    }
+
+private:
+    void session(boost::asio::ip::tcp::socket socket) {
+        using boost::asio::buffer;
+        using boost::asio::read_until;
+        using boost::asio::write;
+
+        const std::string hello =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            "<hello><capabilities>"
+            "<capability>urn:ietf:params:netconf:base:1.0</capability>"
+            "</capabilities></hello>" + eom_;
+        write(socket, buffer(hello));
+
+        boost::asio::streambuf buf;
+        boost::system::error_code ec;
+        while (!ec) {
+            read_until(socket, buf, eom_, ec);
+            if (ec) break;
+            std::istream is(&buf);
+            std::string rpc((std::istreambuf_iterator<char>(is)), {});
+            buf.consume(buf.size());
+            auto pos = rpc.find(eom_);
+            if (pos != std::string::npos)
+                rpc.erase(pos);
+            handle_rpc(rpc, socket);
+        }
+    }
+
+    void handle_rpc(const std::string& rpc,
+                    boost::asio::ip::tcp::socket& sock) {
+        using boost::property_tree::ptree;
+        ptree tree;
+        std::stringstream ss(rpc);
+        try {
+            boost::property_tree::read_xml(ss, tree);
+        } catch (...) {
+            return;
+        }
+
+        ptree reply_tree;
+        std::string msg_id =
+            tree.get<std::string>("rpc.<xmlattr>.message-id", "0");
+
+        if (tree.get_child_optional("rpc.get")) {
+            ptree data;
+            ptree ports_node;
+            for (size_t i = 0; i < ports_.size(); ++i) {
+                ptree port;
+                port.put("<xmlattr>.id", i);
+                port.put("enabled", ports_[i].enabled.load() ? 1 : 0);
+                port.put("frequency", ports_[i].centerFreqMHz.load());
+                ports_node.add_child("port", port);
+            }
+            data.add_child("ports", ports_node);
+            ptree reply_rpc;
+            reply_rpc.put("<xmlattr>.message-id", msg_id);
+            reply_rpc.add_child("data", data);
+            reply_tree.add_child("rpc-reply", reply_rpc);
+        } else if (auto edit = tree.get_child_optional("rpc.edit-config")) {
+            try {
+                auto port_node = edit->get_child("port");
+                size_t id = port_node.get<size_t>("<xmlattr>.id");
+                bool en = port_node.get<bool>("enabled");
+                if (id < ports_.size())
+                    ports_[id].enabled = en;
+                ptree reply_rpc;
+                reply_rpc.put("<xmlattr>.message-id", msg_id);
+                reply_rpc.put("ok", "");
+                reply_tree.add_child("rpc-reply", reply_rpc);
+            } catch (...) {
+                ptree reply_rpc;
+                reply_rpc.put("<xmlattr>.message-id", msg_id);
+                reply_rpc.put("rpc-error", "");
+                reply_tree.add_child("rpc-reply", reply_rpc);
+            }
+        } else {
+            ptree reply_rpc;
+            reply_rpc.put("<xmlattr>.message-id", msg_id);
+            reply_rpc.put("rpc-error", "");
+            reply_tree.add_child("rpc-reply", reply_rpc);
+        }
+
+        std::ostringstream oss;
+        boost::property_tree::write_xml(
+            oss, reply_tree,
+            boost::property_tree::xml_writer_make_settings<std::string>(' ', 0));
+        const std::string reply = oss.str() + eom_;
+        boost::asio::write(sock, boost::asio::buffer(reply));
+    }
+
+    std::vector<PortState>& ports_;
+    boost::asio::io_context ioc_;
+    boost::asio::ip::tcp::acceptor acceptor_;
+    const std::string eom_;
+};
+

--- a/src/daemon/websocket_server.hpp
+++ b/src/daemon/websocket_server.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <thread>
+
+// Simple echo WebSocket server. Launch run() to start listening on the given port.
+class WebSocketServer {
+public:
+    explicit WebSocketServer(unsigned short port)
+        : ioc_(1), acceptor_(ioc_, {boost::asio::ip::tcp::v4(), port}) {}
+
+    // Start the server threads. Connections are handled in detached sessions.
+    void run() {
+        std::thread([this] {
+            for (;;) {
+                boost::asio::ip::tcp::socket socket(ioc_);
+                acceptor_.accept(socket);
+                std::thread(&WebSocketServer::session, this, std::move(socket)).detach();
+            }
+        }).detach();
+        std::thread([this] { ioc_.run(); }).detach();
+    }
+
+private:
+    void session(boost::asio::ip::tcp::socket socket) {
+        namespace websocket = boost::beast::websocket;
+        websocket::stream<boost::asio::ip::tcp::socket> ws(std::move(socket));
+        ws.accept();
+        for (;;) {
+            boost::beast::flat_buffer buffer;
+            ws.read(buffer);
+            ws.text(ws.got_text());
+            ws.write(buffer.data()); // Echo back
+        }
+    }
+
+    boost::asio::io_context ioc_;
+    boost::asio::ip::tcp::acceptor acceptor_;
+};
+

--- a/tests/netconf_server_test.cpp
+++ b/tests/netconf_server_test.cpp
@@ -1,0 +1,48 @@
+#include "daemon/netconf_server.hpp"
+#include "PortState.hpp"
+#include <boost/asio/ip/tcp.hpp>
+#include <cassert>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+int main() {
+    std::vector<PortState> ports(2);
+    ports[1].centerFreqMHz = 123.45;
+
+    NetconfServer server(ports, 8301);
+    server.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    using boost::asio::ip::tcp;
+    boost::asio::io_context ioc;
+    tcp::socket sock(ioc);
+    sock.connect({tcp::v4(), 8301});
+
+    const std::string eom("\x5D\x5D\x3E\x5D\x5D\x3E");
+
+    boost::asio::streambuf buf;
+    boost::asio::read_until(sock, buf, eom);
+    buf.consume(buf.size());
+
+    std::string edit =
+        "<rpc message-id=\"1\"><edit-config><port id=\"1\"><enabled>true" \
+        "</enabled></port></edit-config></rpc>" + eom;
+    boost::asio::write(sock, boost::asio::buffer(edit));
+    boost::asio::read_until(sock, buf, eom);
+    buf.consume(buf.size());
+    assert(ports[1].enabled.load());
+
+    std::string get = "<rpc message-id=\"2\"><get/></rpc>" + eom;
+    boost::asio::write(sock, boost::asio::buffer(get));
+    boost::asio::read_until(sock, buf, eom);
+    std::istream is(&buf);
+    std::string reply((std::istreambuf_iterator<char>(is)), {});
+    buf.consume(buf.size());
+    assert(reply.find("port id=\"1\"") != std::string::npos);
+    assert(reply.find("<enabled>1</enabled>") != std::string::npos);
+    assert(reply.find("<frequency>123.45</frequency>") != std::string::npos);
+
+    return 0;
+}
+

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,33 @@
+# Example Nginx configuration for serving the Angular frontend with TLS
+# termination and forwarding WebSocket traffic to the monitor daemon.
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+upstream daemon_ws {
+    server 127.0.0.1:9002;
+}
+
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name _;
+
+    # TLS certificates
+    ssl_certificate     /etc/nginx/certs/server.crt;
+    ssl_certificate_key /etc/nginx/certs/server.key;
+
+    # Serve compiled Angular assets
+    root /usr/share/nginx/html;
+    try_files $uri $uri/ /index.html;
+
+    # Proxy WebSocket connections to the daemon
+    location /ws {
+        proxy_pass http://daemon_ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}

--- a/web/port-status.component.ts
+++ b/web/port-status.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
 
 interface Port {
   enabled: boolean;
@@ -13,18 +12,19 @@ interface Port {
 })
 export class PortStatusComponent implements OnInit {
   ports: Port[] = [];
+  private socket?: WebSocket;
 
-  constructor(private http: HttpClient) {}
-
-  ngOnInit() { this.refresh(); }
-
-  refresh() {
-    this.http.get<Port[]>('/api/ports').subscribe(data => this.ports = data);
+  ngOnInit() {
+    // Connect via secure WebSocket through the Nginx reverse proxy. The
+    // proxy terminates TLS and forwards `/ws` traffic to the daemon.
+    this.socket = new WebSocket(`wss://${location.host}/ws`);
+    this.socket.onmessage = evt => {
+      this.ports = JSON.parse(evt.data);
+    };
   }
 
   toggle(idx: number) {
     const en = !this.ports[idx].enabled;
-    this.http.post(`/api/ports/${idx}/enable`, { enabled: en })
-        .subscribe(() => this.refresh());
+    this.socket?.send(JSON.stringify({ port: idx, enable: en }));
   }
 }


### PR DESCRIPTION
## Summary
- implement minimal NETCONF server capable of toggling ports and reporting detected frequencies
- wire NETCONF server into monitor daemon and document new control interface
- add test covering NETCONF port enable and frequency query
- add example Nginx config to serve the Angular frontend with TLS termination and proxy WebSocket traffic

## Testing
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68aa26773774832987a07ad5ba99977d